### PR TITLE
Origin/bugfix/beta update equation for non zero location

### DIFF
--- a/gaussian_exponential_mixture.py
+++ b/gaussian_exponential_mixture.py
@@ -23,7 +23,7 @@ class GaussianExponentialParameters:
         exl_loc (float): the location of the start of the exponential distribution.
     """
 
-    def __init__(self, beta=1.0, mu=0.0, sigma=100.0, proportion=0.5, exp_loc=0, **kwargs):
+    def __init__(self, beta=1.0, mu=0.0, sigma=100.0, proportion=0.5, exp_loc=0.0, **kwargs):
         self.beta: float = kwargs.get('beta', beta)
         self.mu: float = kwargs.get('mu', mu)
         self.sigma: float = kwargs.get('sigma', sigma)
@@ -35,8 +35,8 @@ class GaussianExponentialParameters:
 
     def __str__(self) -> str:
         return f'beta: {self.beta:.5f} | mu: {self.mu:.5f} | ' \
-               f'sigma: {self.sigma:.5f} | exp_loc: {self.exp_loc:.5f} \
-                | proportion: {self.proportion:.5f}'
+               f'sigma: {self.sigma:.5f} | exp_loc: {self.exp_loc:.5f} | ' \
+               f'proportion: {self.proportion:.5f}'
 
     def as_list(self) -> list:
         """Gets the parameters as a list.
@@ -145,11 +145,13 @@ class GaussianExponentialMixture:
         """Updates the location parameter of the exponential distribution.
 
          Note:
-            Assumes this parameter is fixed unless it track the Gausian Mu.  There might be a update
-            equation for the normal case that could be added in future
+            Assumes this parameter is fixed unless it tracked the Gaussian Mu.  
+            
+            TODO: Derive an update equation for the location than could be implemented
+            for this to be a free parameter to esitimate
         """
         if self.distribution_fix is True:
-           self.parameters_updated.exp_loc = self.parameters_updated.mu #+ (2*self.parameters_updated.sigma)
+           self.parameters_updated.exp_loc = self.parameters_updated.mu
            
     def _update_sigma(self) -> None:
         """Updates the sigma parameter (standard deviation/scale) of the gaussian distribution.
@@ -185,9 +187,6 @@ class GaussianExponentialMixture:
         need to be applied on each iteration.
         """
         self.norm = stats.norm(loc=self.parameters_updated.mu, scale=self.parameters_updated.sigma)
-    #    if self.distribution_fix is False:
-    #        self.expon = stats.expon(loc=self._exp_loc, scale=self.parameters_updated.beta)
-    #    else:
         self.expon = stats.expon(loc=self.parameters_updated.exp_loc, scale=self.parameters_updated.beta)
 
 


### PR DESCRIPTION
While I got away with this with my initial data, I noticed the beta update equation is incorrect when I used some other data and will not converge if an exp_loc is specified as a parameter as a location other than 0.  The bug can be recreated in below snippet run against master.  

This branch fixes it (line 134) but also moves the exp_loc to being a parameter, although I have not derived the update equation for it being updated as a true free parameter,so you might want to keep it seperate

```python

import numpy
from scipy.stats import expon  
from gaussian_exponential_mixture import GaussianExponentialMixture

beta, mu, sigma, exp_loc = 1, 10, 1, 3

exponential_data = expon.rvs(scale=beta, loc=exp_loc, size=500)
gaussian_data = numpy.random.normal(loc=mu, scale=sigma, size=500)
mixed_data = numpy.append(exponential_data, gaussian_data)
mix = GaussianExponentialMixture(mixed_data, exp_loc=3)
mix.fit()

print(mix.parameters)
```